### PR TITLE
Initial films endpoints

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -158,3 +158,6 @@ project/plugins/project/
 
 # Just ignore all of intellij .idea/ directory
 .idea/
+
+# Environment Vars
+.vars.env

--- a/server/README.md
+++ b/server/README.md
@@ -1,0 +1,86 @@
+# FilmClub Server
+
+### Requirements
+
+- [sbt](https://www.scala-sbt.org/)
+```sh
+brew install sbt
+```
+- [docker](https://hub.docker.com/editions/community/docker-ce-desktop-mac/)
+
+The server makes calls to the [TMDB API](https://developers.themoviedb.org/3/getting-started/introduction).
+This means an API key is required. We'll handle sensitive values with a
+gitignored-file. In the `server` directory of the repo, create a file called
+`.vars.env` (make sure it's _exactly_ this name, otherwise it might get picked
+up by git!). In that file, create an entry named `TMDB_API_KEY` like this:
+```sh
+TMDB_API_KEY=<API-KEY>
+```
+Be sure to replace the `<API-KEY>` value with the actual key. You should only
+have to modify this file once for each entry, then `source` it for each terminal
+session as described below.
+
+
+### Running
+
+#### Server
+
+Navigate to the `server` directory.
+
+To use the database, start the local Postgres image using Docker:
+```sh
+docker-compose up &
+```
+
+Source the env file to make sure the environment variables are available to the
+server:
+```sh
+source .vars.env
+```
+
+Use `sbt` to run the server:
+```sh
+sbt run
+```
+
+You should now be able to make requests to various `localhost:8080` endpoints:
+
+##### `echo`
+
+There's an `echo` path to try out various requests for testing.
+
+- **GET** `localhost:8080/v1/echo/hello/{name}` will respond with
+```
+Hello, {name}!
+```
+
+- **GET** `localhost:8080/v1/echo/int/{n}` will respond with a JSON payload
+like this:
+```json
+{
+  "selected": 5
+}
+```
+This endpoint can be used to check the connection to the database.
+
+- **POST** `localhost:8080/v1/echo/person` with a JSON payload with
+  - `name`: `String`
+  - `age`: `Number` -- needs to be greater than 0
+```json
+{
+  "name": "Jon Snow",
+  "age": 35
+}
+```
+will echo the same payload back if it is acceptable. If the payload failed, it
+will respond with an error.
+
+##### `films`
+
+The beginning functionality for the server is started at the `films` path.
+
+- **GET** `localhost:8080/v1/films/upcoming` will provide a paginated list of
+films that will be released soon, in ascending order by their release-date.
+
+- **GET** `localhost:8080/v1/films/images/{imagePath}`, where `imagePath` is
+either a `poster` or `backdrop`, will return the raw image data (`jpg`).

--- a/server/README.md
+++ b/server/README.md
@@ -43,6 +43,10 @@ Use `sbt` to run the server:
 sbt run
 ```
 
+This may take a while to start up. You should eventually see a message that says
+```
+http4s v0.21.13 on blaze v0.14.14 started at http://[::]:8080/
+```
 You should now be able to make requests to various `localhost:8080` endpoints:
 
 ##### `echo`
@@ -80,7 +84,52 @@ will respond with an error.
 The beginning functionality for the server is started at the `films` path.
 
 - **GET** `localhost:8080/v1/films/upcoming` will provide a paginated list of
-films that will be released soon, in ascending order by their release-date.
+films that will be released soon, in ascending order by their release-date. The
+top level response will be JSON with the following properties:
+- `films`: Array of `Film`s
+- `page`: Number of current page
+- `totalPages`: Number of total pages for available for this query
+- `totalResults`: Total number of films available for this query
+
+A `Film` payload looks like the following:
+```json
+{
+  "backdropPath": "/srYya1ZlI97Au4jUYAktDe3avyA.jpg",
+  "genres": [
+    {
+      "id": 14,
+      "name": "Fantasy"
+    },
+    {
+      "id": 28,
+      "name": "Action"
+    },
+    {
+      "id": 12,
+      "name": "Adventure"
+    }
+  ],
+  "id": 464052,
+  "originalLanguage": "en",
+  "originalTitle": "Wonder Woman 1984",
+  "overview": "Wonder Woman comes into conflict with the Soviet Union during the Cold War in the 1980s and finds a formidable foe by the name of the Cheetah.",
+  "popularity": 974.114,
+  "posterPath": "/di1bCAfGoJ0BzNEavLsPyxQ2AaB.jpg",
+  "releaseDate": "2020-12-25",
+  "title": "Wonder Woman 1984",
+  "voteAverage": 7.1,
+  "voteCount": 111
+}
+```
 
 - **GET** `localhost:8080/v1/films/images/{imagePath}`, where `imagePath` is
 either a `poster` or `backdrop`, will return the raw image data (`jpg`).
+
+### Shutdown
+
+To shutdown the service, use `ctrl+c` to exit out of the running server. Then
+use
+```sh
+docker-compose down
+```
+to terminate the database.

--- a/server/build.sbt
+++ b/server/build.sbt
@@ -19,6 +19,7 @@ lazy val ScalaCheckVersion = "1.15.1"
 libraryDependencies ++= Seq(
   // http
   "org.http4s"            %% "http4s-blaze-server"    % Http4sVersion,
+  "org.http4s"            %% "http4s-blaze-client"    % Http4sVersion,
   "org.http4s"            %% "http4s-circe"           % Http4sVersion,
   "org.http4s"            %% "http4s-dsl"             % Http4sVersion,
 
@@ -30,6 +31,7 @@ libraryDependencies ++= Seq(
   "org.http4s"            %% "http4s-circe"           % Http4sVersion,
   "io.circe"              %% "circe-core"             % CirceVersion,
   "io.circe"              %% "circe-generic"          % CirceVersion,
+  "io.circe"              %% "circe-generic-extras"   % CirceVersion,
   "io.circe"              %% "circe-refined"          % CirceVersion,
 
   // database
@@ -54,10 +56,10 @@ libraryDependencies ++= Seq(
 )
 
 // these don't seem to play well with tagless-final style
-wartremoverErrors ++= Warts.allBut(
+wartremoverErrors in (Compile, compile) ++= Warts.allBut(
   Wart.Any,
   Wart.Nothing,
-  Wart.GlobalExecutionContext // this is fine
+  Wart.GlobalExecutionContext, // this is fine
 )
 
 resolvers += Resolver.sonatypeRepo("releases")
@@ -65,7 +67,7 @@ addCompilerPlugin("org.typelevel" %% "kind-projector"     % "0.11.2" cross Cross
 addCompilerPlugin("com.olegpy"    %% "better-monadic-for" % "0.3.1")
 addCompilerPlugin(scalafixSemanticdb)
 scalacOptions += "-Yrangepos"
-scalacOptions += "-Ywarn-unused"
+scalacOptions += "-Ymacro-annotations"
 
 Compile / run / fork := true
 

--- a/server/build.sbt
+++ b/server/build.sbt
@@ -49,6 +49,9 @@ libraryDependencies ++= Seq(
   // logging
   "ch.qos.logback"        %  "logback-classic"        % LogbackVersion,
 
+  // Date / Time
+  "joda-time"             % "joda-time"               % "2.10.8",
+
   // tests
   "org.scalatest"         %% "scalatest"              % ScalaTestVersion  % Test,
   "org.scalacheck"        %% "scalacheck"             % ScalaCheckVersion % Test,

--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -12,6 +12,7 @@ app {
   }
   tmdb {
     base-uri = "https://api.themoviedb.org/3/"
+    images-uri = "https://image.tmdb.org/t/p/original"
     api-key = ${?TMDB_API_KEY}
   }
 }

--- a/server/src/main/resources/application.conf
+++ b/server/src/main/resources/application.conf
@@ -10,4 +10,8 @@ app {
     user = "postgres"
     pass = "postgres"
   }
+  tmdb {
+    base-uri = "https://api.themoviedb.org/3/"
+    api-key = ${?TMDB_API_KEY}
+  }
 }

--- a/server/src/main/scala/com/molo/filmclub/AppConfig.scala
+++ b/server/src/main/scala/com/molo/filmclub/AppConfig.scala
@@ -1,26 +1,29 @@
 package com.molo.filmclub
 
 import cats.effect.{Blocker, ContextShift, Resource, Sync}
+import com.molo.filmclub.client.TmdbConfig
 import pureconfig._
 import pureconfig.generic.auto._
 import pureconfig.module.catseffect.syntax._
+import pureconfig.module.http4s._
 
 final case class DbConfig(
-    connectionThreads: Int,
-    driver: String,
-    url: String,
-    user: String,
-    pass: String
+  connectionThreads: Int,
+  driver: String,
+  url: String,
+  user: String,
+  pass: String
 )
 
 final case class HttpConfig(
-    port: Int,
-    host: String
+  port: Int,
+  host: String
 )
 
 final case class AppConfig(
-    http: HttpConfig,
-    db: DbConfig
+  http: HttpConfig,
+  db: DbConfig,
+  tmdb: TmdbConfig
 )
 
 object AppConfig {

--- a/server/src/main/scala/com/molo/filmclub/AppError.scala
+++ b/server/src/main/scala/com/molo/filmclub/AppError.scala
@@ -7,8 +7,11 @@ import org.http4s.dsl.Http4sDsl
 import org.http4s.{HttpApp, Response}
 
 sealed trait AppError extends Exception with Product with Serializable
+
 object AppError {
+
   case object InvalidBody extends AppError
+
 }
 
 class ErrorHandler[F[_]](service: HttpApp[F])(implicit ev: ApplicativeError[F, Throwable]) extends Http4sDsl[F] {

--- a/server/src/main/scala/com/molo/filmclub/FilmsService.scala
+++ b/server/src/main/scala/com/molo/filmclub/FilmsService.scala
@@ -1,0 +1,25 @@
+package com.molo.filmclub
+
+import cats.effect.Sync
+import cats.implicits._
+import com.molo.filmclub.client.FilmDataClient
+import org.http4s.circe._
+import org.http4s.dsl.Http4sDsl
+import org.http4s.server.Router
+import org.http4s.{EntityEncoder, HttpRoutes}
+
+final class FilmsService[F[_]: Sync](client: FilmDataClient[F]) extends Http4sDsl[F] {
+  import com.molo.filmclub.client.FilmDataClient._
+
+  private object PageQueryParam extends OptionalQueryParamDecoderMatcher[Int]("page")
+
+  private implicit val discoveredFilmEntityEncoder: EntityEncoder[F, LatestFilmsResponse] = jsonEncoderOf[F, LatestFilmsResponse]
+
+  private val http: HttpRoutes[F] = HttpRoutes.of[F] {
+    case GET -> Root / "latest" :? PageQueryParam(page) =>
+      client.getLatestFilms(page).flatMap(Ok(_))
+  }
+
+  val routes: HttpRoutes[F] = Router("films" -> http)
+
+}

--- a/server/src/main/scala/com/molo/filmclub/FilmsService.scala
+++ b/server/src/main/scala/com/molo/filmclub/FilmsService.scala
@@ -5,8 +5,9 @@ import cats.implicits._
 import com.molo.filmclub.client.FilmDataClient
 import org.http4s.circe._
 import org.http4s.dsl.Http4sDsl
+import org.http4s.headers.`Content-Type`
 import org.http4s.server.Router
-import org.http4s.{EntityEncoder, HttpRoutes}
+import org.http4s.{EntityEncoder, HttpRoutes, MediaType}
 
 final class FilmsService[F[_]: Sync](client: FilmDataClient[F]) extends Http4sDsl[F] {
   import com.molo.filmclub.client.FilmDataClient._
@@ -18,6 +19,9 @@ final class FilmsService[F[_]: Sync](client: FilmDataClient[F]) extends Http4sDs
   private val http: HttpRoutes[F] = HttpRoutes.of[F] {
     case GET -> Root / "upcoming" :? PageQueryParam(page) =>
       client.getUpcomingFilms(page).flatMap(Ok(_))
+
+    case GET -> Root / "images" / imgPath =>
+      Ok(client.getImage(imgPath), `Content-Type`(MediaType.image.jpeg))
   }
 
   val routes: HttpRoutes[F] = Router("films" -> http)

--- a/server/src/main/scala/com/molo/filmclub/FilmsService.scala
+++ b/server/src/main/scala/com/molo/filmclub/FilmsService.scala
@@ -1,7 +1,6 @@
 package com.molo.filmclub
 
 import cats.effect.Sync
-import cats.implicits._
 import com.molo.filmclub.client.FilmDataClient
 import org.http4s.circe._
 import org.http4s.dsl.Http4sDsl
@@ -18,7 +17,7 @@ final class FilmsService[F[_]: Sync](client: FilmDataClient[F]) extends Http4sDs
 
   private val http: HttpRoutes[F] = HttpRoutes.of[F] {
     case GET -> Root / "upcoming" :? PageQueryParam(page) =>
-      client.getUpcomingFilms(page).flatMap(Ok(_))
+      Ok(client.getUpcomingFilms(page))
 
     case GET -> Root / "images" / imgPath =>
       Ok(client.getImage(imgPath), `Content-Type`(MediaType.image.jpeg))

--- a/server/src/main/scala/com/molo/filmclub/FilmsService.scala
+++ b/server/src/main/scala/com/molo/filmclub/FilmsService.scala
@@ -13,11 +13,11 @@ final class FilmsService[F[_]: Sync](client: FilmDataClient[F]) extends Http4sDs
 
   private object PageQueryParam extends OptionalQueryParamDecoderMatcher[Int]("page")
 
-  private implicit val discoveredFilmEntityEncoder: EntityEncoder[F, LatestFilmsResponse] = jsonEncoderOf[F, LatestFilmsResponse]
+  private implicit val discoveredFilmEntityEncoder: EntityEncoder[F, UpcomingFilmsResponse] = jsonEncoderOf[F, UpcomingFilmsResponse]
 
   private val http: HttpRoutes[F] = HttpRoutes.of[F] {
-    case GET -> Root / "latest" :? PageQueryParam(page) =>
-      client.getLatestFilms(page).flatMap(Ok(_))
+    case GET -> Root / "upcoming" :? PageQueryParam(page) =>
+      client.getUpcomingFilms(page).flatMap(Ok(_))
   }
 
   val routes: HttpRoutes[F] = Router("films" -> http)

--- a/server/src/main/scala/com/molo/filmclub/Server.scala
+++ b/server/src/main/scala/com/molo/filmclub/Server.scala
@@ -1,19 +1,28 @@
 package com.molo.filmclub
 
+import cats.implicits._
 import cats.effect._
+import com.molo.filmclub.client.TmdbClient
 import doobie.util.transactor.Transactor
 import org.http4s._
+import org.http4s.client.Client
+import org.http4s.client.blaze.BlazeClientBuilder
 import org.http4s.implicits._
+import org.http4s.server.Router
 import org.http4s.server.blaze.BlazeServerBuilder
 
 import scala.concurrent.ExecutionContext.global
 
 object Server extends IOApp {
 
-  private def buildServices(xa: Transactor[IO]): IO[HttpApp[IO]] =
+  private def buildServices(config: AppConfig, client: Client[IO], xa: Transactor[IO]): IO[HttpApp[IO]] =
     IO {
-      val dao = new EchoDao[IO](xa)
-      val app = new EchoService[IO](dao).routes.orNotFound
+      val echoDao = new EchoDao[IO](xa)
+      val echoSvs = new EchoService[IO](echoDao)
+      val filmClient = new TmdbClient[IO](client, config.tmdb)
+      val filmsSvs = new FilmsService[IO](filmClient)
+      val services = echoSvs.routes <+> filmsSvs.routes
+      val app = Router("/v1" -> services).orNotFound
       new ErrorHandler(app).wrapped
     }
 
@@ -25,17 +34,18 @@ object Server extends IOApp {
       .compile
       .drain
 
-  private def resources: Resource[IO, (AppConfig, Transactor[IO])] =
+  private def resources: Resource[IO, (AppConfig, Client[IO], Transactor[IO])] =
     for {
       blocker    <- Blocker[IO]
       config     <- AppConfig.resource[IO](blocker)
+      client     <- BlazeClientBuilder[IO](global).resource
       transactor <- Database.transactor[IO](config.db, blocker)
-    } yield (config, transactor)
+    } yield (config, client, transactor)
 
   override def run(args: List[String]): IO[ExitCode] =
-    resources.use { case (cfg, xa) =>
+    resources.use { case (cfg, client, xa) =>
       for {
-        app <- buildServices(xa)
+        app <- buildServices(cfg, client, xa)
         _   <- startServer(cfg.http, app)
       } yield ExitCode.Success
     }

--- a/server/src/main/scala/com/molo/filmclub/client/FilmDataClient.scala
+++ b/server/src/main/scala/com/molo/filmclub/client/FilmDataClient.scala
@@ -3,9 +3,13 @@ package com.molo.filmclub.client
 import com.molo.filmclub.client.FilmDataClient.UpcomingFilmsResponse
 import io.circe.generic.JsonCodec
 
+import fs2.Stream
+
 trait FilmDataClient[F[_]] {
 
   def getUpcomingFilms(page: Option[Int]): F[UpcomingFilmsResponse]
+
+  def getImage(path: String): Stream[F, Byte]
 
 }
 

--- a/server/src/main/scala/com/molo/filmclub/client/FilmDataClient.scala
+++ b/server/src/main/scala/com/molo/filmclub/client/FilmDataClient.scala
@@ -1,11 +1,11 @@
 package com.molo.filmclub.client
 
-import com.molo.filmclub.client.FilmDataClient.LatestFilmsResponse
+import com.molo.filmclub.client.FilmDataClient.UpcomingFilmsResponse
 import io.circe.generic.JsonCodec
 
 trait FilmDataClient[F[_]] {
 
-  def getLatestFilms(page: Option[Int]): F[LatestFilmsResponse]
+  def getUpcomingFilms(page: Option[Int]): F[UpcomingFilmsResponse]
 
 }
 
@@ -15,7 +15,7 @@ object FilmDataClient {
   type GenreId = Int
 
   @JsonCodec(encodeOnly = true)
-  final case class LatestFilmsResponse(
+  final case class UpcomingFilmsResponse(
     films: List[Film],
     page: Int,
     totalPages: Int,

--- a/server/src/main/scala/com/molo/filmclub/client/FilmDataClient.scala
+++ b/server/src/main/scala/com/molo/filmclub/client/FilmDataClient.scala
@@ -1,0 +1,75 @@
+package com.molo.filmclub.client
+
+import com.molo.filmclub.client.FilmDataClient.LatestFilmsResponse
+import io.circe.generic.JsonCodec
+
+trait FilmDataClient[F[_]] {
+
+  def getLatestFilms(page: Option[Int]): F[LatestFilmsResponse]
+
+}
+
+object FilmDataClient {
+
+  type FilmId = Int
+  type GenreId = Int
+
+  @JsonCodec(encodeOnly = true)
+  final case class LatestFilmsResponse(
+    films: List[Film],
+    page: Int,
+    totalPages: Int,
+    totalResults: Int
+  )
+
+  @JsonCodec(encodeOnly = true)
+  final case class Film(
+    backdropPath: Option[String],
+    genres: List[Genre],
+    id: FilmId,
+    originalLanguage: String,
+    originalTitle: String,
+    overview: String,
+    popularity: Double,
+    posterPath: Option[String],
+    releaseDate: String,
+    title: String,
+    voteAverage: Double,
+    voteCount: Double
+  )
+
+  @JsonCodec(encodeOnly = true)
+  final case class Genre(id: GenreId, name: String)
+
+  object Genre {
+    private val idToName: Map[GenreId, String] = Map(
+      28 -> "Action",
+      12 -> "Adventure",
+      16 -> "Animation",
+      35 -> "Comedy",
+      80 -> "Crime",
+      99 -> "Documentary",
+      18 -> "Drama",
+      10751 -> "Family",
+      14 -> "Fantasy",
+      36 -> "History",
+      27 -> "Horror",
+      10402 -> "Music",
+      9648 -> "Mystery",
+      10749 -> "Romance",
+      878 -> "Science Fiction",
+      10770 -> "TV Movie",
+      53 -> "Thriller",
+      10752 -> "War",
+      37 -> "Western"
+      )
+    private val nameToId: Map[String, GenreId] = idToName.map(_.swap)
+
+    def fromId(id: GenreId): Option[Genre] =
+      idToName.get(id).map(Genre(id, _))
+
+    def fromName(name: String): Option[Genre] =
+      nameToId.get(name).map(Genre(_, name))
+  }
+
+}

--- a/server/src/main/scala/com/molo/filmclub/client/TmdbClient.scala
+++ b/server/src/main/scala/com/molo/filmclub/client/TmdbClient.scala
@@ -1,0 +1,84 @@
+package com.molo.filmclub.client
+
+import cats.effect._
+import cats.implicits._
+import com.molo.filmclub.client.FilmDataClient.LatestFilmsResponse
+
+import org.http4s.circe.jsonOf
+import org.http4s.client.Client
+import org.http4s.client.dsl.Http4sClientDsl
+import org.http4s.{EntityDecoder, Request, Uri}
+
+final case class TmdbConfig(baseUri: Uri, apiKey: String) {
+  def defaultParams(): Map[String, String] =
+    Map("api_key" -> apiKey, "language" -> "en-US")
+}
+
+final class TmdbClient[F[_] : Sync](client: Client[F], config: TmdbConfig) extends FilmDataClient[F] with Http4sClientDsl[F] {
+
+  import TmdbClient._
+
+  private implicit val discoverFilmsResponseEntityDecoder: EntityDecoder[F, DiscoverFilmsResponse] = jsonOf[F, DiscoverFilmsResponse]
+
+  override def getLatestFilms(page: Option[Int]): F[LatestFilmsResponse] = {
+    val uri = config.baseUri / "discover" / "movie"
+    val params = config.defaultParams() + ("page" -> page.getOrElse(1).toString)
+    val req = Request[F](uri = uri.withQueryParams(params))
+    client.fetchAs[DiscoverFilmsResponse](req).map(_.toLatestFilmsResponse())
+  }
+}
+
+object TmdbClient {
+
+  import FilmDataClient._
+  import io.circe.generic.extras._
+
+  implicit val customJsonConfig: Configuration = Configuration.default.withSnakeCaseMemberNames
+
+  @ConfiguredJsonCodec(decodeOnly = true)
+  final case class DiscoveredFilm(
+    backdropPath: Option[String],
+    genreIds: List[Int],
+    id: Int,
+    originalLanguage: String,
+    originalTitle: String,
+    overview: String,
+    popularity: Double,
+    posterPath: Option[String],
+    releaseDate: String,
+    title: String,
+    voteAverage: Double,
+    voteCount: Double
+  ) {
+    def toFilm(): Film = Film(
+      backdropPath = backdropPath,
+      genres = genreIds.flatMap(Genre.fromId),
+      id = id,
+      originalLanguage = originalLanguage,
+      originalTitle = originalTitle,
+      overview = overview,
+      popularity = popularity,
+      posterPath = posterPath,
+      releaseDate = releaseDate,
+      title = title,
+      voteAverage = voteAverage,
+      voteCount = voteCount
+      )
+  }
+
+  @ConfiguredJsonCodec(decodeOnly = true)
+  final case class DiscoverFilmsResponse(
+    page: Int,
+    results: List[DiscoveredFilm],
+    totalPages: Int,
+    totalResults: Int
+  ) {
+    def toLatestFilmsResponse(): LatestFilmsResponse = LatestFilmsResponse(
+      films = results.map(_.toFilm()),
+      page = page,
+      totalPages = totalPages,
+      totalResults = totalResults
+      )
+  }
+
+}


### PR DESCRIPTION
This PR adds the initial `films` endpoints for fetching the "upcoming" films and a general-purpose "images" endpoint for a film's poster and backdrop. It also adds a server-level README which has details on how to run the server and the endpoints it exposes.