### PR TITLE
Remove 'releaseDate' as a required field from 'Film' and 'FilmDetail'

### DIFF
--- a/specs/filmclub.yaml
+++ b/specs/filmclub.yaml
@@ -240,7 +240,6 @@ components:
         - originalTitle
         - overview
         - popularity
-        - releaseDate
         - title
         - voteAverage
         - voteCount
@@ -313,7 +312,6 @@ components:
         - originalTitle
         - overview
         - popularity
-        - releaseDate
         - status
         - title
         - voteAverage


### PR DESCRIPTION
Some films don't have published release dates! See gstro/film-club-server#38
Closes #38 